### PR TITLE
Always build htslib without the libdeflate library

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -80,3 +80,4 @@ export(variant.genotypes.allele.counts)
 export(variant.genotypes.allele.strings)
 
 export(variant.genotypes.set.int.attribute)
+export(variant.genotypes.set.allele.strings)

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -79,3 +79,4 @@ export(variant.genotypes.allele.idx0)
 export(variant.genotypes.allele.counts)
 export(variant.genotypes.allele.strings)
 
+export(variant.genotypes.set.int.attribute)

--- a/R/rbcf.R
+++ b/R/rbcf.R
@@ -810,8 +810,7 @@ variant.genotypes.float.attribute <- function(vc, att) {
 #' @return the variant `vc`
 #'
 #' @seealso
-#'    \link{variant.genotypes.flag.attribute},
-#'    \link{variant.genotypes.float.attribute}
+#'    \link{variant.genotypes.int.attribute}
 #'
 variant.genotypes.set.int.attribute <- function(vc, att, values) {
   stopifnot(looks_like_variant_context(vc))
@@ -821,6 +820,30 @@ variant.genotypes.set.int.attribute <- function(vc, att, values) {
   .Call("VariantGenotypesSetInt32Attribute", vc, att, as.integer(values))
 }
 
+#' Set the genotypes `FORMAT/GT` for all genotype call of a variant
+#'
+#' The vector must contain the values in the order of `bcf.samples`:
+#' ```
+#'   Sample1, Sample2, Sample3
+#' c(  "0/1",   "0/0",      NA)
+#' ```
+#' 
+#' The `NA` will be replaces by ".".
+#'
+#' @param vc the variant
+#' @param values a characters vector containing the genotype calls (see details)
+#'
+#' @return the variant `vc`
+#'
+#' @seealso
+#'    \link{variant.genotypes.allele.strings}
+#'
+variant.genotypes.set.allele.strings <- function(vc, values) {
+  stopifnot(looks_like_variant_context(vc))
+  stopifnot(is.character(values))
+  values[ is.na(values) ] <- "."
+  .Call("VariantGenotypesSetAllGtStrings", vc, as.character(values))
+}
 
 
 

--- a/R/rbcf.R
+++ b/R/rbcf.R
@@ -793,6 +793,37 @@ variant.genotypes.float.attribute <- function(vc, att) {
 	.Call("VariantGenotypesFloatAttribute", vc, att)
 }
 
+#' Set a specific FORMAT integer value on all genotypes
+#'
+#' The vector must contain the values by sample and attribute number (if the attribute comprises multiple integer values).
+#'
+#' For example, for a 3 sample VCF extracting the allelic read depth (AD) on a singleton variant, the would look like:
+#' ```
+#'   GT1-REF, GT1-ALT, GT2-REF, GT2-ALT, GT3-REF, GT3-ALT
+#' c(     10,     100,      25,      94,      45,       7)
+#' ```
+#'
+#' @param vc the variant
+#' @param att a character vector containing the variant attribute
+#' @param values a numeric vector to set the value (will be converted to integer)
+#'
+#' @return the variant `vc`
+#'
+#' @seealso
+#'    \link{variant.genotypes.flag.attribute},
+#'    \link{variant.genotypes.float.attribute}
+#'
+variant.genotypes.set.int.attribute <- function(vc, att, values) {
+  stopifnot(looks_like_variant_context(vc))
+  stopifnot(is.character(att))
+  stopifnot(length(att) == 1)
+  stopifnot(is.numeric(values))
+  .Call("VariantGenotypesSetInt32Attribute", vc, att, as.integer(values))
+}
+
+
+
+
 #' @param gt the genotype
 #' @param att the key
 #' @return the values for this key+genotype

--- a/src/rbcf.c
+++ b/src/rbcf.c
@@ -1532,13 +1532,14 @@ SEXP RBcfCtxVariantAllGtStrings(SEXP sexpCtx) {
         // if true, the sample has smaller ploidy
         if (bcf_gt_is_missing(gt_arr[k])) {
           buf_ptr[0] = '.';
+          buf_ptr[1] = '\0';
           buf_ptr++;
-        } else {
+        } else { 
           buf_ptr += sprintf(buf_ptr, "%d", bcf_gt_allele(gt_arr[k]));
+          buf_ptr[0] = '\0';
         }
       }
     }
-    buf_ptr[0] = '\0';
     SET_STRING_ELT(ext, i, mkChar(buf));
   }
   free(buf);

--- a/src/rbcf.c
+++ b/src/rbcf.c
@@ -1524,13 +1524,11 @@ SEXP RBcfCtxVariantAllGtStrings(SEXP sexpCtx) {
       // if true, the sample has smaller ploidy
       if (gt_arr[k] == bcf_int32_vector_end) {
         buf_ptr[0] = '-';
-        buf_ptr[1] = '\0';
-        buf_ptr += 2;
+        buf_ptr++;
       }
       else if (bcf_gt_is_missing(gt_arr[k])) {
         buf_ptr[0] = '.';
-        buf_ptr[1] = '\0';
-        buf_ptr += 2;
+        buf_ptr++;
       } else {
         buf_ptr += sprintf(buf_ptr, "%d", bcf_gt_allele(gt_arr[k]));
       }

--- a/src/rbcf.c
+++ b/src/rbcf.c
@@ -1512,27 +1512,33 @@ SEXP RBcfCtxVariantAllGtStrings(SEXP sexpCtx) {
     buf_ptr = buf;
     for (j=0; j<max_ploidy; j++) {
       k = i * max_ploidy + j;
-      if (j > 0) {
-        // If this is not the first allele-index add a separator
-        if (bcf_gt_is_phased(gt_arr[k]) ){
-          buf_ptr[0] = '|';
-        } else {
-          buf_ptr[0] = '/';
-        }
-        buf_ptr++;
-      }
-      // if true, the sample has smaller ploidy
+      
+      // If the current index is array-end, stop parsing here
       if (gt_arr[k] == bcf_int32_vector_end) {
-        buf_ptr[0] = '-';
-        buf_ptr++;
+        buf_ptr[0] = '\0';
+        j = max_ploidy;
       }
-      else if (bcf_gt_is_missing(gt_arr[k])) {
-        buf_ptr[0] = '.';
-        buf_ptr++;
-      } else {
-        buf_ptr += sprintf(buf_ptr, "%d", bcf_gt_allele(gt_arr[k]));
+      else {
+        if (j > 0) {
+          // If this is not the first allele-index add a separator
+          if (bcf_gt_is_phased(gt_arr[k]) ){
+            buf_ptr[0] = '|';
+          } else {
+            buf_ptr[0] = '/';
+          }
+          buf_ptr++;
+        }
+        
+        // if true, the sample has smaller ploidy
+        if (bcf_gt_is_missing(gt_arr[k])) {
+          buf_ptr[0] = '.';
+          buf_ptr++;
+        } else {
+          buf_ptr += sprintf(buf_ptr, "%d", bcf_gt_allele(gt_arr[k]));
+        }
       }
     }
+    buf_ptr[0] = '\0';
     SET_STRING_ELT(ext, i, mkChar(buf));
   }
   free(buf);

--- a/tests/0200.update_format.R
+++ b/tests/0200.update_format.R
@@ -1,0 +1,47 @@
+##Writing variants to a new VCF/BCF file
+# load rbcf
+library(rbcf)
+# vcf input filename
+filenamein = "./data/1000G.ALL.2of4intersection.20100804.genotypes.bcf"
+# output vcf filename. "-" is standard output
+filenameout =  "-"
+
+fp <- bcf.open(filenamein,FALSE)
+# error on opening (exit 0 for tests)
+if(is.null(fp)) quit(save="no",status=0,runLast=FALSE)
+
+# create a new VCF writer using the header from 'fp'
+out <- bcf.new.writer(fp,filenameout)
+# error on opening (exit 0 for tests)
+if(is.null(out)) quit(save="no",status=0,runLast=FALSE)
+
+n_samples <- bcf.nsamples(fp)
+
+# loop while we can read a variant
+while(!is.null(vc<-bcf.next(fp))) {
+  # Setting of INT attributes
+  old_dp <- variant.genotypes.int.attribute(vc, "DP")
+  new_dp <- rnbinom(n = n_samples, size = 5, prob = 0.25)
+  variant.genotypes.set.int.attribute(vc, "DP", new_dp)
+  stopifnot( all(  new_dp == variant.genotypes.int.attribute(vc, "DP") ))
+  
+  # Updating GT with random allele combinations
+  alleles <- c(".", as.character(0:variant.nalleles(vc)))
+  all_potential_genotypes = c(".",
+    apply(as.matrix(expand.grid(alleles, alleles)), 1, paste, collapse = "/"),
+    apply(as.matrix(expand.grid(0:variant.nalleles(vc), 0:variant.nalleles(vc))), 1, paste, collapse = "|")
+  )
+  
+  new_gt <- sample(x = all_potential_genotypes, size = n_samples, replace = TRUE)
+  variant.genotypes.set.allele.strings(vc, new_gt)
+  new_gt <- sub("-", ".", new_gt)
+  subset(data.frame( Expected = new_gt, Seen = variant.genotypes.allele.strings(vc)), Expected != Seen)
+  
+  stopifnot(all(  new_gt == variant.genotypes.allele.strings(vc) ))
+  
+  bcf.write.variant(out, vc)
+}
+# dispose the vcf reader
+bcf.close(fp)
+# dispose the vcf rwriter
+bcf.close(out)


### PR DESCRIPTION
If libdeflate is installed on the host, the configure script for htslib will
pick it up and link with it, leading to undefined symbols in the final link
since -ldeflate is missing from PKG_LIBS. We also cannot simply add it to
PKG_LIBS, since then we would get an error on hosts where libdeflate is
unavailable, so just configure htslib without libdeflate support.